### PR TITLE
Update permissions for the contextual filter

### DIFF
--- a/config/sync/views.view.trainer_diary_view.yml
+++ b/config/sync/views.view.trainer_diary_view.yml
@@ -158,7 +158,7 @@ display:
             type: 'entity:user'
             fail: 'not found'
           validate_options:
-            access: true
+            access: false
             operation: view
             multiple: 0
             restrict_roles: false


### PR DESCRIPTION
- Adjusted Views contextual filter permission
![image](https://github.com/CUPA-mario/pokemon-diary/assets/40708149/3d588d76-96e2-4ae4-8b5a-13376289a861)

Content and listing should now be visible for anonymous users,